### PR TITLE
refactor: integrate design tokens and dark mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "tailwindcss": "^4.1.11"
   },
   "devDependencies": {
-    "@astrojs/node": "^8.3.1"
+    "@astrojs/node": "^9.0.0"
   }
 }

--- a/src/components/AppointmentSuccess.tsx
+++ b/src/components/AppointmentSuccess.tsx
@@ -27,11 +27,11 @@ export default function AppointmentSuccess({ professional, service, slot, sessio
   return (
     <div className="text-center p-8">
       <img src="/check-success.svg" alt="Éxito" className="w-16 h-16 mx-auto mb-4" />
-      <h2 className="text-2xl font-bold mb-2 text-success">Cita agendada</h2>
-      <p className="text-gray-700 mb-4">
+      <h2 className="text-2xl font-bold mb-2 text-primary">Cita agendada</h2>
+      <p className="mb-4 text-foreground">
         Tu cita con {professional.displayName} está confirmada para {format(slot, "eeee d 'de' MMMM 'a las' HH:mm", { locale: es })}.
       </p>
-      <div className="text-left space-y-1 text-gray-700">
+      <div className="text-left space-y-1 text-foreground">
         <p><span className="font-semibold">Ubicación:</span> {sessionType}</p>
         <p><span className="font-semibold">Duración:</span> {service.duration} min</p>
         <p><span className="font-semibold">Costo:</span> {service.price > 0 ? `$${service.price.toLocaleString('es-CL')}` : 'Gratis'}</p>

--- a/src/components/BookingForm.tsx
+++ b/src/components/BookingForm.tsx
@@ -86,30 +86,30 @@ export default function BookingForm({ professionalId, selectedService, selectedS
 
   return (
     <div className="mt-8 pt-6 border-t">
-      <h2 className="text-2xl font-bold text-gray-700 mb-2">3. Confirma tus datos</h2>
-      <div className="p-6 border rounded-xl bg-white mt-4">
+      <h2 className="text-2xl font-bold text-foreground mb-2">3. Confirma tus datos</h2>
+      <div className="p-6 border rounded-xl bg-card mt-4">
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label htmlFor="clientName" className="text-sm font-medium text-gray-700">Nombre y Apellido</label>
-            <input type="text" name="clientName" id="clientName" value={formData.clientName} onChange={handleChange} className="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 rounded-lg" required />
+            <label htmlFor="clientName" className="text-sm font-medium text-foreground">Nombre y Apellido</label>
+            <input type="text" name="clientName" id="clientName" value={formData.clientName} onChange={handleChange} className="w-full px-4 py-3 mt-1 bg-muted rounded-lg text-foreground" required />
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <label htmlFor="clientEmail" className="text-sm font-medium text-gray-700">Correo Electrónico</label>
-              <input type="email" name="clientEmail" id="clientEmail" value={formData.clientEmail} onChange={handleChange} className="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 rounded-lg" required />
+              <label htmlFor="clientEmail" className="text-sm font-medium text-foreground">Correo Electrónico</label>
+              <input type="email" name="clientEmail" id="clientEmail" value={formData.clientEmail} onChange={handleChange} className="w-full px-4 py-3 mt-1 bg-muted rounded-lg text-foreground" required />
             </div>
             <div>
-              <label htmlFor="clientPhone" className="text-sm font-medium text-gray-700">Teléfono (Opcional)</label>
-              <input type="tel" name="clientPhone" id="clientPhone" value={formData.clientPhone} onChange={handleChange} className="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 rounded-lg" />
+              <label htmlFor="clientPhone" className="text-sm font-medium text-foreground">Teléfono (Opcional)</label>
+              <input type="tel" name="clientPhone" id="clientPhone" value={formData.clientPhone} onChange={handleChange} className="w-full px-4 py-3 mt-1 bg-muted rounded-lg text-foreground" />
             </div>
           </div>
           <div>
-            <label htmlFor="notes" className="text-sm font-medium text-gray-700">Notas</label>
-            <textarea name="notes" id="notes" rows={3} value={formData.notes} onChange={handleChange} className="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 rounded-lg"></textarea>
+            <label htmlFor="notes" className="text-sm font-medium text-foreground">Notas</label>
+            <textarea name="notes" id="notes" rows={3} value={formData.notes} onChange={handleChange} className="w-full px-4 py-3 mt-1 bg-muted rounded-lg text-foreground"></textarea>
           </div>
-          {error && <p className="text-sm text-red-600">{error}</p>}
+          {error && <p className="text-sm text-destructive">{error}</p>}
           <div className="flex justify-end pt-4">
-            <button type="submit" disabled={isLoading} className="flex items-center justify-center w-48 px-6 py-3 font-semibold text-white rounded-lg shadow-md bg-primary-700 hover:bg-primary-400 disabled:bg-primary-400/50">
+            <button type="submit" disabled={isLoading} className="flex items-center justify-center w-48 px-6 py-3 font-semibold rounded-lg shadow-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:bg-primary/50">
               {isLoading ? 'Agendando...' : 'Realizar Reserva'}
             </button>
           </div>

--- a/src/components/Scheduler.tsx
+++ b/src/components/Scheduler.tsx
@@ -125,28 +125,28 @@ export default function Scheduler({ professional, services }: Props) {
       {!selectedService ? (
         <>
             <div className="mb-6">
-              <h2 className="text-xl font-bold text-gray-800">1. Selecciona un servicio</h2>
-              <p className="text-gray-500 mt-1">Elige uno para ver los horarios disponibles.</p>
+              <h2 className="text-xl font-bold text-foreground">1. Selecciona un servicio</h2>
+              <p className="text-muted-foreground mt-1">Elige uno para ver los horarios disponibles.</p>
             </div>
             <div className="space-y-4">
               {services.map((service) => (
                 <div
                   key={service.id}
-                  className="bg-white p-4 rounded-xl shadow-sm border border-gray-200 flex justify-between items-center transition hover:shadow-md hover:border-primary-400"
+                  className="bg-card p-4 rounded-xl shadow-sm border flex justify-between items-center transition hover:shadow-md hover:border-primary"
                 >
                   <div>
-                    <h3 className="font-semibold text-gray-900">{service.name}</h3>
-                  <div className="flex items-center gap-x-4 text-sm text-gray-500 mt-1">
+                    <h3 className="font-semibold text-foreground">{service.name}</h3>
+                  <div className="flex items-center gap-x-4 text-sm text-muted-foreground mt-1">
                     <span>{service.duration} min</span>
-                    <span className="w-1 h-1 bg-gray-300 rounded-full"></span>
-                    <span className="font-medium text-gray-700">
+                    <span className="w-1 h-1 bg-muted-foreground rounded-full"></span>
+                    <span className="font-medium text-foreground">
                       {service.price > 0 ? `$${service.price.toLocaleString('es-CL')}` : 'Gratis'}
                     </span>
                   </div>
                 </div>
                   <button
                     onClick={() => handleSelectService(service)}
-                    className="bg-primary-700 text-white font-semibold px-5 py-2 rounded-lg hover:bg-primary-400 transition-colors"
+                    className="bg-primary text-primary-foreground font-semibold px-5 py-2 rounded-lg hover:bg-primary/90 transition-colors"
                   >
                     Elegir
                   </button>
@@ -158,7 +158,7 @@ export default function Scheduler({ professional, services }: Props) {
         // Pasos 2 y 3: Calendario y formulario
         <div>
           <div className="mb-6">
-            <h2 className="text-xl font-bold text-gray-800">2. Elige un día y una hora</h2>
+            <h2 className="text-xl font-bold text-foreground">2. Elige un día y una hora</h2>
           </div>
 
           <div className="flex gap-2 mb-4">
@@ -168,8 +168,8 @@ export default function Scheduler({ professional, services }: Props) {
                 onClick={() => setSessionType(type as 'PRESENCIAL' | 'ONLINE')}
                 className={`px-4 py-2 rounded-lg border font-semibold ${
                   sessionType === type
-                    ? 'bg-primary-700 text-white border-primary-700'
-                    : 'bg-white text-primary-700 border-primary-700 hover:bg-primary-400 hover:text-white'
+                    ? 'bg-primary text-primary-foreground border-primary'
+                    : 'bg-background text-primary border-primary hover:bg-primary hover:text-primary-foreground'
                 }`}
               >
                 {type}
@@ -178,14 +178,14 @@ export default function Scheduler({ professional, services }: Props) {
           </div>
 
           {/* Resumen del servicio seleccionado */}
-          <div className="flex justify-between items-center bg-gray-50 p-3 rounded-xl border mb-6">
+          <div className="flex justify-between items-center bg-muted p-3 rounded-xl border mb-6">
             <div>
-              <p className="text-xs text-gray-500">Servicio seleccionado</p>
-              <p className="font-semibold text-gray-800">{selectedService.name}</p>
+              <p className="text-xs text-muted-foreground">Servicio seleccionado</p>
+              <p className="font-semibold text-foreground">{selectedService.name}</p>
             </div>
             <button
               onClick={() => handleSelectService(null)}
-              className="text-sm text-primary-700 hover:underline font-semibold"
+              className="text-sm text-primary hover:underline font-semibold"
             >
               Cambiar
             </button>
@@ -193,7 +193,7 @@ export default function Scheduler({ professional, services }: Props) {
 
           {/* Calendario y horarios */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
-            <div className="bg-white p-3 rounded-xl shadow-sm border border-gray-200 flex justify-center">
+            <div className="bg-card p-3 rounded-xl shadow-sm border flex justify-center">
               <DayPicker
                 mode="single"
                 selected={selectedDay}
@@ -209,32 +209,32 @@ export default function Scheduler({ professional, services }: Props) {
                   nav_button: 'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100',
                   table: 'w-full border-collapse space-y-1',
                   head_row: 'flex',
-                  head_cell: 'text-gray-500 rounded-md w-9 font-normal text-[0.8rem]',
+                  head_cell: 'text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]',
                   row: 'flex w-full mt-2',
                   cell:
-                    'h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected])]:bg-primary-400 first:[&:has([aria-selected])]:rounded-l-lg last:[&:has([aria-selected])]:rounded-r-lg focus-within:relative focus-within:z-20',
+                    'h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected])]:bg-primary/90 first:[&:has([aria-selected])]:rounded-l-lg last:[&:has([aria-selected])]:rounded-r-lg focus-within:relative focus-within:z-20',
                   day: 'h-9 w-9 p-0 font-normal aria-selected:opacity-100',
                   day_selected:
-                    'bg-primary-700 text-white hover:bg-primary-700 hover:text-white focus:bg-primary-700 focus:text-white rounded-lg',
-                  day_today: 'bg-gray-100 text-gray-900',
-                  day_outside: 'text-gray-400 opacity-50',
-                  day_disabled: 'text-gray-400 opacity-50',
+                    'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground rounded-lg',
+                  day_today: 'bg-muted text-foreground',
+                  day_outside: 'text-muted-foreground opacity-50',
+                  day_disabled: 'text-muted-foreground opacity-50',
                   day_hidden: 'invisible',
                 }}
               />
             </div>
             <div className="h-full">
               {selectedDay && (
-                <p className="text-center text-sm font-semibold text-gray-800 mb-2">
+                <p className="text-center text-sm font-semibold text-foreground mb-2">
                   Horarios para el {format(selectedDay, "eeee, d 'de' MMMM", { locale: es })}
                 </p>
               )}
-              <div className="p-2 border rounded-xl h-72 overflow-y-auto bg-gray-50">
+              <div className="p-2 border rounded-xl h-72 overflow-y-auto bg-muted">
                 {isLoading && (
-                  <p className="text-gray-400 text-center pt-4 animate-pulse">Buscando...</p>
+                  <p className="text-muted-foreground text-center pt-4 animate-pulse">Buscando...</p>
                 )}
                 {!isLoading && availableSlots.length === 0 && (
-                  <p className="text-gray-400 text-center pt-4">
+                  <p className="text-muted-foreground text-center pt-4">
                     {selectedDay ? 'No hay horarios disponibles.' : 'Selecciona un día.'}
                   </p>
                 )}
@@ -246,8 +246,8 @@ export default function Scheduler({ professional, services }: Props) {
                         onClick={() => handleSlotSelect(slot)}
                         className={`p-2 rounded-lg text-center font-semibold transition-colors border ${
                           selectedSlot?.getTime() === slot.getTime()
-                            ? 'bg-primary-700 text-white border-primary-700 shadow-md'
-                            : 'bg-white text-primary-700 border-primary-700 hover:bg-primary-400 hover:text-white'
+                            ? 'bg-primary text-primary-foreground border-primary shadow-md'
+                            : 'bg-background text-primary border-primary hover:bg-primary hover:text-primary-foreground'
                         }`}
                       >
                         {format(slot, 'HH:mm')}
@@ -262,7 +262,7 @@ export default function Scheduler({ professional, services }: Props) {
             <div className="flex justify-end mt-4">
               <button
                 onClick={() => setShowForm(true)}
-                className="px-6 py-2 bg-primary-700 text-white rounded-lg hover:bg-primary-400"
+                className="px-6 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90"
               >
                 Continuar
               </button>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -8,8 +8,8 @@ photoURL?: string;
 }
 
 interface Props {
-title: string;
-professional: Professional;
+  title: string;
+  professional?: Professional;
 }
 
 const { title, professional } = Astro.props;
@@ -29,14 +29,14 @@ const { title, professional } = Astro.props;
                 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
                 <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;700;800&display=swap" rel="stylesheet">
         </head>
-        <body class="bg-gray-100 font-sans text-gray-800">
+        <body>
                 <div class="flex items-center justify-center min-h-screen">
-                        <div class="w-full max-w-md bg-white rounded-2xl shadow-lg overflow-hidden m-4">
-                                <header class="bg-primary-700 text-white p-6 flex items-center gap-4">
-                                        <img src={professional.photoURL || '/avatar.svg'} alt={`Foto de ${professional.displayName}`} class="w-16 h-16 rounded-full object-cover border-4 border-white" />
+                        <div class="w-full max-w-md bg-card rounded-2xl shadow-lg overflow-hidden m-4">
+                                <header class="bg-primary text-primary-foreground p-6 flex items-center gap-4">
+                                        <img src={professional?.photoURL || '/avatar.svg'} alt={`Foto de ${professional?.displayName || 'profesional'}`} class="w-16 h-16 rounded-full object-cover border-4 border-background" />
                                         <div>
-                                                <h1 class="text-xl font-bold">{professional.displayName}</h1>
-                                                <p class="text-sm">{professional.title}</p>
+                                                <h1 class="text-xl font-bold">{professional?.displayName}</h1>
+                                                <p class="text-sm">{professional?.title}</p>
                                         </div>
                                 </header>
                                 <div class="p-6">

--- a/src/pages/agendar/[professionalId].astro
+++ b/src/pages/agendar/[professionalId].astro
@@ -43,7 +43,7 @@ if (!professional) {
 }
 ---
 
-<Layout title={`Agendar con ${professional.displayName}`}>
+<Layout title={`Agendar con ${professional.displayName}`} professional={professional}>
   <Scheduler
     client:load
     professional={{

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,80 @@
 @import "tailwindcss";
 
-body {
-  @apply font-sans text-gray-800;
+:root {
+  --background: 0 0% 100%;
+  --foreground: 224 71% 4%;
+  --card: 0 0% 100%;
+  --card-foreground: 224 71% 4%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 224 71% 4%;
+  --primary: 263 63% 41%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 220 14% 96%;
+  --secondary-foreground: 224 71% 4%;
+  --muted: 220 14% 96%;
+  --muted-foreground: 220 8% 46%;
+  --accent: 220 14% 96%;
+  --accent-foreground: 224 71% 4%;
+  --destructive: 0 84% 60%;
+  --destructive-foreground: 0 0% 100%;
+  --border: 220 13% 91%;
+  --input: 220 13% 91%;
+  --ring: 263 63% 41%;
+  --radius: 0.5rem;
+  --font-sans: "Montserrat", sans-serif;
+}
+
+.dark {
+  --background: 224 71% 4%;
+  --foreground: 210 40% 98%;
+  --card: 224 71% 4%;
+  --card-foreground: 210 40% 98%;
+  --popover: 224 71% 4%;
+  --popover-foreground: 210 40% 98%;
+  --primary: 263 63% 56%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 217 32% 17%;
+  --secondary-foreground: 210 40% 98%;
+  --muted: 217 32% 17%;
+  --muted-foreground: 215 20% 65%;
+  --accent: 217 32% 17%;
+  --accent-foreground: 210 40% 98%;
+  --destructive: 0 63% 30%;
+  --destructive-foreground: 0 0% 100%;
+  --border: 217 32% 17%;
+  --input: 217 32% 17%;
+  --ring: 263 63% 56%;
+}
+
+@theme inline {
+  --color-background: hsl(var(--background));
+  --color-foreground: hsl(var(--foreground));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-accent: hsl(var(--accent));
+  --color-accent-foreground: hsl(var(--accent-foreground));
+  --color-destructive: hsl(var(--destructive));
+  --color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-border: hsl(var(--border));
+  --color-input: hsl(var(--input));
+  --color-ring: hsl(var(--ring));
+  --radius: var(--radius);
+  --font-sans: var(--font-sans);
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground font-sans;
+  }
 }

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,28 +1,7 @@
-// Tailwind CSS configuration defining custom colors, fonts and plugins
+import tailwindcss from '@tailwindcss/vite';
+import forms from '@tailwindcss/forms';
+
 export default {
   content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
-  theme: {
-    extend: {
-      colors: {
-        primary: {
-          DEFAULT: '#5224af',
-          400: '#a57cf0',
-          700: '#5224af',
-        },
-        success: '#8cc63f',
-      },
-      fontFamily: {
-        sans: ['"Montserrat"', 'sans-serif'],
-      },
-      borderRadius: {
-        lg: '0.5rem',
-        xl: '1rem',
-        '2xl': '1.5rem',
-      },
-    },
-  },
-  // Enable form styling utilities
-  plugins: [
-    require('@tailwindcss/forms'),
-  ],
-}
+  plugins: [tailwindcss(), forms],
+};


### PR DESCRIPTION
## Summary
- pass professional data into layout and make professional optional
- implement CSS variable design tokens with dark theme support
- configure Tailwind to use tokens and update components to new utilities
- update @astrojs/node to ^9.0.0

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@astrojs%2finternal-helpers)*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: astro: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fac39944c8327b99f779ecb115360