### PR TITLE
Listar profesionales desde Firestore

### DIFF
--- a/src/components/AppointmentSuccess.tsx
+++ b/src/components/AppointmentSuccess.tsx
@@ -31,12 +31,20 @@ export default function AppointmentSuccess({ professional, service, slot, sessio
         <img src="/check-success.svg" alt="Éxito" className="w-16 h-16 mx-auto mb-4" />
         <h2 className="text-2xl font-bold mb-2 text-foreground">¡Cita agendada!</h2>
         <p className="mb-4 text-muted-foreground">
-          Tu cita con {professional.displayName} está confirmada para {format(slot, "eeee d 'de' MMMM 'a las' HH:mm", { locale: es })}.
+          Tu cita con {professional.displayName} está confirmada para{' '}
+          {format(slot, "eeee d 'de' MMMM 'a las' HH:mm", { locale: es })}.
         </p>
         <div className="text-left space-y-1 text-foreground">
-          <p><span className="font-semibold">Ubicación:</span> {sessionType}</p>
-          <p><span className="font-semibold">Duración:</span> {service.duration} min</p>
-          <p><span className="font-semibold">Costo:</span> {service.price > 0 ? `$${service.price.toLocaleString('es-CL')}` : 'Gratis'}</p>
+          <p>
+            <span className="font-semibold">Ubicación:</span> {sessionType}
+          </p>
+          <p>
+            <span className="font-semibold">Duración:</span> {service.duration} min
+          </p>
+          <p>
+            <span className="font-semibold">Costo:</span>{' '}
+            {service.price > 0 ? `$${service.price.toLocaleString('es-CL')}` : 'Gratis'}
+          </p>
         </div>
         <div className="mt-6">
           <button
@@ -50,3 +58,4 @@ export default function AppointmentSuccess({ professional, service, slot, sessio
     </div>
   );
 }
+

--- a/src/components/AppointmentSuccess.tsx
+++ b/src/components/AppointmentSuccess.tsx
@@ -24,39 +24,6 @@ interface Props {
 }
 
 export default function AppointmentSuccess({ professional, service, slot, sessionType }: Props) {
-  const handleAddToCalendar = () => {
-    const end = new Date(slot.getTime() + service.duration * 60000);
-    const ics = [
-      'BEGIN:VCALENDAR',
-      'VERSION:2.0',
-      'BEGIN:VEVENT',
-      `DTSTART:${format(slot, "yyyyMMdd'T'HHmmss")}`,
-      `DTEND:${format(end, "yyyyMMdd'T'HHmmss")}`,
-      `SUMMARY:${service.name}`,
-      'END:VEVENT',
-      'END:VCALENDAR',
-    ].join('\r\n');
-    const blob = new Blob([ics], { type: 'text/calendar;charset=utf-8' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = 'cita.ics';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
-  };
-
-  const handleShare = async () => {
-    const text = `Cita con ${professional.displayName} el ${format(slot, "eeee d 'de' MMMM 'a las' HH:mm", { locale: es })} (${sessionType})`;
-    try {
-      await navigator.clipboard.writeText(text);
-      alert('Cita copiada al portapapeles');
-    } catch (err) {
-      alert('No se pudo copiar la cita');
-    }
-  };
-
   return (
     <div className="text-center p-8">
       <img src="/check-success.svg" alt="Éxito" className="w-16 h-16 mx-auto mb-4" />
@@ -69,20 +36,12 @@ export default function AppointmentSuccess({ professional, service, slot, sessio
         <p><span className="font-semibold">Duración:</span> {service.duration} min</p>
         <p><span className="font-semibold">Costo:</span> {service.price > 0 ? `$${service.price.toLocaleString('es-CL')}` : 'Gratis'}</p>
       </div>
-      <div className="flex flex-col sm:flex-row gap-4 justify-center mt-6">
-        <button
-          onClick={handleAddToCalendar}
-          className="px-4 py-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90"
-        >
-          Agregar al calendario
-        </button>
-        <button
-          onClick={handleShare}
-          className="px-4 py-2 rounded-lg border border-primary text-primary hover:bg-primary hover:text-primary-foreground"
-        >
-          Compartir cita
-        </button>
-      </div>
+      <a
+        href={`/agendar/${professional.id}`}
+        className="block w-full px-4 py-2 mt-6 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90"
+      >
+        Volver al inicio
+      </a>
     </div>
   );
 }

--- a/src/components/AppointmentSuccess.tsx
+++ b/src/components/AppointmentSuccess.tsx
@@ -21,27 +21,32 @@ interface Props {
   service: Service;
   slot: Date;
   sessionType: string;
+  onRestart: () => void;
 }
 
-export default function AppointmentSuccess({ professional, service, slot, sessionType }: Props) {
+export default function AppointmentSuccess({ professional, service, slot, sessionType, onRestart }: Props) {
   return (
-    <div className="text-center p-8">
-      <img src="/check-success.svg" alt="Éxito" className="w-16 h-16 mx-auto mb-4" />
-      <h2 className="text-2xl font-bold mb-2 text-primary">Cita agendada</h2>
-      <p className="mb-4 text-foreground">
-        Tu cita con {professional.displayName} está confirmada para {format(slot, "eeee d 'de' MMMM 'a las' HH:mm", { locale: es })}.
-      </p>
-      <div className="text-left space-y-1 text-foreground">
-        <p><span className="font-semibold">Ubicación:</span> {sessionType}</p>
-        <p><span className="font-semibold">Duración:</span> {service.duration} min</p>
-        <p><span className="font-semibold">Costo:</span> {service.price > 0 ? `$${service.price.toLocaleString('es-CL')}` : 'Gratis'}</p>
+    <div className="w-full flex justify-center">
+      <div className="max-w-md text-center bg-card p-8 rounded-xl border shadow-sm">
+        <img src="/check-success.svg" alt="Éxito" className="w-16 h-16 mx-auto mb-4" />
+        <h2 className="text-2xl font-bold mb-2 text-foreground">¡Cita agendada!</h2>
+        <p className="mb-4 text-muted-foreground">
+          Tu cita con {professional.displayName} está confirmada para {format(slot, "eeee d 'de' MMMM 'a las' HH:mm", { locale: es })}.
+        </p>
+        <div className="text-left space-y-1 text-foreground">
+          <p><span className="font-semibold">Ubicación:</span> {sessionType}</p>
+          <p><span className="font-semibold">Duración:</span> {service.duration} min</p>
+          <p><span className="font-semibold">Costo:</span> {service.price > 0 ? `$${service.price.toLocaleString('es-CL')}` : 'Gratis'}</p>
+        </div>
+        <div className="mt-6">
+          <button
+            onClick={onRestart}
+            className="w-full px-4 py-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90"
+          >
+            Volver al inicio
+          </button>
+        </div>
       </div>
-      <a
-        href={`/agendar/${professional.id}`}
-        className="block w-full px-4 py-2 mt-6 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90"
-      >
-        Volver al inicio
-      </a>
     </div>
   );
 }

--- a/src/components/BookingForm.tsx
+++ b/src/components/BookingForm.tsx
@@ -54,11 +54,13 @@ export default function BookingForm({ professionalId, selectedService, selectedS
   };
 
   return (
-    <div className="mt-8 pt-6 max-w-xl mx-auto">
-      <h2 className="text-2xl font-bold text-foreground mb-2">Confirma tus datos</h2>
-      <p className="text-muted-foreground mb-6">
-        Revisa y completa tu información para confirmar la reserva.
-      </p>
+    <div className="mt-6 max-w-xl mx-auto">
+      <div className="mb-6">
+        <h2 className="text-xl font-bold text-foreground">Confirma tus datos</h2>
+        <p className="text-muted-foreground mt-1">
+          Revisa y completa tu información para confirmar la reserva.
+        </p>
+      </div>
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
         <div>
           <label htmlFor="clientName" className="text-sm font-medium text-foreground">Nombre y Apellido</label>

--- a/src/components/BookingForm.tsx
+++ b/src/components/BookingForm.tsx
@@ -55,7 +55,7 @@ export default function BookingForm({ professionalId, selectedService, selectedS
 
   return (
     <div className="mt-8 pt-6 max-w-xl mx-auto">
-      <h2 className="text-2xl font-bold text-foreground mb-2">3. Confirma tus datos</h2>
+      <h2 className="text-2xl font-bold text-foreground mb-2">Confirma tus datos</h2>
       <p className="text-muted-foreground mb-6">
         Revisa y completa tu información para confirmar la reserva.
       </p>

--- a/src/components/ProfessionalCard.tsx
+++ b/src/components/ProfessionalCard.tsx
@@ -1,0 +1,26 @@
+interface Props {
+  id: string;
+  displayName: string;
+  title: string;
+  photoURL?: string;
+}
+
+// Card displaying a professional and linking to their scheduling page
+export default function ProfessionalCard({ id, displayName, title, photoURL }: Props) {
+  return (
+    <a
+      href={`/agendar/${id}`}
+      className="flex items-center gap-4 p-4 bg-card rounded-xl shadow hover:shadow-lg transition"
+    >
+      <img
+        src={photoURL || '/avatar.svg'}
+        alt={`Foto de ${displayName}`}
+        className="w-16 h-16 rounded-full object-cover"
+      />
+      <div>
+        <h2 className="text-lg font-bold text-foreground">{displayName}</h2>
+        <p className="text-sm text-muted-foreground">{title}</p>
+      </div>
+    </a>
+  );
+}

--- a/src/components/ProfessionalCard.tsx
+++ b/src/components/ProfessionalCard.tsx
@@ -10,7 +10,7 @@ export default function ProfessionalCard({ id, displayName, title, photoURL }: P
   return (
     <a
       href={`/agendar/${id}`}
-      className="flex items-center gap-4 p-4 bg-card rounded-xl shadow hover:shadow-lg transition"
+      className="flex items-center gap-4 p-4 bg-card rounded-xl shadow-sm border transition hover:shadow-md hover:border-primary"
     >
       <img
         src={photoURL || '/avatar.svg'}

--- a/src/components/Scheduler.tsx
+++ b/src/components/Scheduler.tsx
@@ -162,14 +162,8 @@ export default function Scheduler({ professional, services }: Props) {
     return (
       <div className="w-full">
         <Stepper />
-        <div className="mb-6 text-center">
-          <h1 className="text-2xl font-bold text-foreground">Agenda tu atención</h1>
-          <p className="text-muted-foreground mt-1">
-            Sigue los pasos para completar tu reserva.
-          </p>
-        </div>
         <div className="mb-6">
-          <h2 className="text-xl font-bold text-foreground">1. Selecciona un servicio</h2>
+          <h2 className="text-xl font-bold text-foreground">Selecciona un servicio</h2>
           <p className="text-muted-foreground mt-1">
             Elige uno para ver los horarios disponibles.
           </p>
@@ -232,7 +226,7 @@ export default function Scheduler({ professional, services }: Props) {
       <div className="w-full">
         <Stepper />
         <div className="mb-6">
-          <h2 className="text-xl font-bold text-foreground">2. Elige un día y una hora</h2>
+          <h2 className="text-xl font-bold text-foreground">Elige un día y una hora</h2>
           <p className="text-muted-foreground mt-1">
             Elige uno de los servicios a continuación para ver los horarios disponibles.
           </p>

--- a/src/components/Scheduler.tsx
+++ b/src/components/Scheduler.tsx
@@ -162,9 +162,17 @@ export default function Scheduler({ professional, services }: Props) {
     return (
       <div className="w-full">
         <Stepper />
-        <div className="mb-6">
-          <h2 className="text-xl font-bold text-foreground">1. Selecciona un servicio</h2>
-          <p className="text-muted-foreground mt-1">Elige uno para ver los horarios disponibles.</p>
+        <div className="mb-6 flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-bold text-foreground">1. Selecciona un servicio</h2>
+            <p className="text-muted-foreground mt-1">Elige uno para ver los horarios disponibles.</p>
+          </div>
+          <a
+            href="/"
+            className="text-sm text-primary hover:underline font-semibold whitespace-nowrap mt-1"
+          >
+            Inicio
+          </a>
         </div>
         <div className="space-y-4">
           {services.map((service) => (

--- a/src/components/Scheduler.tsx
+++ b/src/components/Scheduler.tsx
@@ -162,17 +162,17 @@ export default function Scheduler({ professional, services }: Props) {
     return (
       <div className="w-full">
         <Stepper />
-        <div className="mb-6 flex items-start justify-between gap-4">
-          <div>
-            <h2 className="text-xl font-bold text-foreground">1. Selecciona un servicio</h2>
-            <p className="text-muted-foreground mt-1">Elige uno para ver los horarios disponibles.</p>
-          </div>
-          <a
-            href="/"
-            className="text-sm text-primary hover:underline font-semibold whitespace-nowrap mt-1"
-          >
-            Inicio
-          </a>
+        <div className="mb-6 text-center">
+          <h1 className="text-2xl font-bold text-foreground">Agenda tu atención</h1>
+          <p className="text-muted-foreground mt-1">
+            Sigue los pasos para completar tu reserva.
+          </p>
+        </div>
+        <div className="mb-6">
+          <h2 className="text-xl font-bold text-foreground">1. Selecciona un servicio</h2>
+          <p className="text-muted-foreground mt-1">
+            Elige uno para ver los horarios disponibles.
+          </p>
         </div>
         <div className="space-y-4">
           {services.map((service) => (
@@ -198,6 +198,14 @@ export default function Scheduler({ professional, services }: Props) {
               </button>
             </div>
           ))}
+        </div>
+        <div className="flex justify-start pt-6">
+          <a
+            href="/"
+            className="flex items-center justify-center w-full md:w-auto px-8 py-3 font-semibold rounded-lg border text-foreground hover:bg-muted transition-colors"
+          >
+            Volver al inicio
+          </a>
         </div>
       </div>
     );

--- a/src/components/Scheduler.tsx
+++ b/src/components/Scheduler.tsx
@@ -145,6 +145,19 @@ export default function Scheduler({ professional, services }: Props) {
     setBookingSuccess(true);
   };
 
+  const handleRestart = () => {
+    setSelectedService(null);
+    setSelectedDay(undefined);
+    setCurrentWeek(startOfWeek(new Date(), { weekStartsOn: 1 }));
+    setSelectedSlot(null);
+    setAvailableSlots([]);
+    setIsLoading(false);
+    setBookingSuccess(false);
+    setSessionType('PRESENCIAL');
+    setShowForm(false);
+    setBookingDetails(null);
+  };
+
   // Vista de éxito
   if (bookingSuccess && bookingDetails) {
     return (
@@ -153,6 +166,7 @@ export default function Scheduler({ professional, services }: Props) {
         service={bookingDetails.service}
         slot={bookingDetails.slot}
         sessionType={bookingDetails.sessionType}
+        onRestart={handleRestart}
       />
     );
   }
@@ -164,9 +178,7 @@ export default function Scheduler({ professional, services }: Props) {
         <Stepper />
         <div className="mb-6">
           <h2 className="text-xl font-bold text-foreground">Selecciona un servicio</h2>
-          <p className="text-muted-foreground mt-1">
-            Elige uno para ver los horarios disponibles.
-          </p>
+          <p className="text-muted-foreground mt-1">Elige uno para ver los horarios disponibles.</p>
         </div>
         <div className="space-y-4">
           {services.map((service) => (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,20 +1,51 @@
 ---
-import Layout from '../layouts/Layout.astro';
-import Scheduler from '../components/Scheduler';
+import '../styles/global.css';
+import ProfessionalCard from '../components/ProfessionalCard';
+import { db } from '../firebase/client';
+import { collection, getDocs } from 'firebase/firestore';
+import type { DocumentData } from 'firebase/firestore';
 
-const professional = {
-  id: '1',
-  displayName: 'Dr. Juan Pérez',
-  title: 'Psicólogo',
-  photoURL: '/avatar.svg'
-};
+interface Professional {
+  id: string;
+  displayName: string;
+  title: string;
+  photoURL?: string;
+}
 
-const services = [
-  { id: 'svc1', name: 'Consulta inicial', duration: 60, price: 40000 },
-  { id: 'svc2', name: 'Sesión de seguimiento', duration: 45, price: 30000 },
-];
+const snapshot = await getDocs(collection(db, 'professionals'));
+const professionals: Professional[] = snapshot.docs.map(doc => {
+  const data = doc.data() as DocumentData;
+  return {
+    id: doc.id,
+    displayName: data.displayName,
+    title: data.title,
+    photoURL: data.photoURL,
+  };
+});
 ---
 
-<Layout title="Agenda" professional={professional}>
-  <Scheduler professional={professional} services={services} />
-</Layout>
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="description" content="Sistema de Agendamiento" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <title>Agenda</title>
+  </head>
+  <body>
+    <div class="min-h-screen flex items-center justify-center">
+      <div class="w-full max-w-2xl p-6 grid gap-6">
+        {professionals.map((professional) => (
+          <ProfessionalCard
+            key={professional.id}
+            id={professional.id}
+            displayName={professional.displayName}
+            title={professional.title}
+            photoURL={professional.photoURL}
+          />
+        ))}
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -36,8 +36,11 @@ const professionals: Professional[] = snapshot.docs.map(doc => {
 <body>
     <div class="flex items-center justify-center min-h-screen">
       <div class="w-full max-w-md bg-card rounded-2xl shadow-lg overflow-hidden m-4">
-        <header class="bg-primary text-primary-foreground p-6">
-          <h1 class="text-xl font-bold">Agenda tu cita</h1>
+        <header class="bg-primary text-primary-foreground p-6 text-center">
+          <h1 class="text-xl font-bold">Agenda tu atención</h1>
+          <p class="text-sm text-primary-foreground/90 mt-1">
+            Sigue los pasos para completar tu reserva.
+          </p>
         </header>
         <div class="p-6 space-y-4">
           {professionals.map((professional) => (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -33,18 +33,23 @@ const professionals: Professional[] = snapshot.docs.map(doc => {
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Agenda</title>
   </head>
-  <body>
-    <div class="min-h-screen flex items-center justify-center">
-      <div class="w-full max-w-2xl p-6 grid gap-6">
-        {professionals.map((professional) => (
-          <ProfessionalCard
-            key={professional.id}
-            id={professional.id}
-            displayName={professional.displayName}
-            title={professional.title}
-            photoURL={professional.photoURL}
-          />
-        ))}
+<body>
+    <div class="flex items-center justify-center min-h-screen">
+      <div class="w-full max-w-md bg-card rounded-2xl shadow-lg overflow-hidden m-4">
+        <header class="bg-primary text-primary-foreground p-6">
+          <h1 class="text-xl font-bold">Agenda tu cita</h1>
+        </header>
+        <div class="p-6 space-y-4">
+          {professionals.map((professional) => (
+            <ProfessionalCard
+              key={professional.id}
+              id={professional.id}
+              displayName={professional.displayName}
+              title={professional.title}
+              photoURL={professional.photoURL}
+            />
+          ))}
+        </div>
       </div>
     </div>
   </body>


### PR DESCRIPTION
## Resumen
- Añade componente `ProfessionalCard` para mostrar datos del profesional.
- Consulta la colección `professionals` desde Firestore y renderiza tarjetas con enlace a `/agendar/<id>`.
- Ajusta la lista para incluir `key` por tarjeta y elimina importaciones de React innecesarias.

## Testing
- `npm test` *(falla: Missing script "test")*
- `npm run build` *(falla: astro: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ff3bcc2cc83279014fe37e83259dd