### PR TITLE
refactor: type booking form data

### DIFF
--- a/src/components/BookingForm.tsx
+++ b/src/components/BookingForm.tsx
@@ -10,6 +10,13 @@ interface Service {
   duration: number;
 }
 
+interface BookingFormData {
+  clientName: string;
+  clientEmail: string;
+  clientPhone: string;
+  notes: string;
+}
+
 interface Props {
   professionalId: string | undefined;
   selectedService: Service;
@@ -20,7 +27,7 @@ interface Props {
 
 // Form that submits client information to create a booking
 export default function BookingForm({ professionalId, selectedService, selectedSlot, onBookingSuccess, onBack }: Props) {
-  const { register, handleSubmit, formState: { errors, isValid, isSubmitting } } = useForm({
+  const { register, handleSubmit, formState: { errors, isValid, isSubmitting } } = useForm<BookingFormData>({
     mode: 'onChange',
     defaultValues: {
       clientName: '',
@@ -30,7 +37,7 @@ export default function BookingForm({ professionalId, selectedService, selectedS
     }
   });
 
-  const onSubmit = async (data: any) => {
+  const onSubmit = async (data: BookingFormData): Promise<void> => {
     if (!professionalId || !selectedService || !selectedSlot) {
       return;
     }


### PR DESCRIPTION
## Summary
- define `BookingFormData` and use it to type the booking form
- type `onSubmit` and form hooks for stronger validation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0bc67ab1c8327803a944d213d6acd