### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -17,32 +17,60 @@ const { title, professional } = Astro.props;
 
 <!doctype html>
 <html lang="es">
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="description" content="Sistema de Agendamiento" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="generator" content={Astro.generator} />
-		<title>{title}</title>
+        <head>
+                <meta charset="UTF-8" />
+                <meta name="description" content="Sistema de Agendamiento" />
+                <meta name="viewport" content="width=device-width" />
+                <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+                <meta name="generator" content={Astro.generator} />
+                <title>{title}</title>
 
-                <link rel="preconnect" href="https://fonts.googleapis.com">
-                <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-                <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;700;800&display=swap" rel="stylesheet">
+                <link rel="preconnect" href="https://fonts.googleapis.com" />
+                <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+                <link
+                        href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;700;800&display=swap"
+                        rel="stylesheet"
+                />
+                <script is:inline>
+                        const theme = localStorage.getItem('theme');
+                        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                        if (theme === 'dark' || (!theme && prefersDark)) {
+                                document.documentElement.classList.add('dark');
+                        }
+                </script>
         </head>
         <body>
                 <div class="flex items-center justify-center min-h-screen">
                         <div class="w-full max-w-md bg-card rounded-2xl shadow-lg overflow-hidden m-4">
                                 <header class="bg-primary text-primary-foreground p-6 flex items-center gap-4">
-                                        <img src={professional?.photoURL || '/avatar.svg'} alt={`Foto de ${professional?.displayName || 'profesional'}`} class="w-16 h-16 rounded-full object-cover border-4 border-background" />
+                                        <img
+                                                src={professional?.photoURL || '/avatar.svg'}
+                                                alt={`Foto de ${professional?.displayName || 'profesional'}`}
+                                                class="w-16 h-16 rounded-full object-cover border-4 border-primary-foreground"
+                                        />
                                         <div>
                                                 <h1 class="text-xl font-bold">{professional?.displayName}</h1>
                                                 <p class="text-sm">{professional?.title}</p>
                                         </div>
+                                        <button
+                                                id="theme-toggle"
+                                                type="button"
+                                                aria-label="Cambiar tema"
+                                                class="ml-auto text-2xl"
+                                        >
+                                                🌓
+                                        </button>
                                 </header>
                                 <div class="p-6">
                                         <slot />
                                 </div>
                         </div>
                 </div>
+                <script>
+                        document.getElementById('theme-toggle')?.addEventListener('click', () => {
+                                const isDark = document.documentElement.classList.toggle('dark');
+                                localStorage.setItem('theme', isDark ? 'dark' : 'light');
+                        });
+                </script>
         </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,15 +32,32 @@ const professionals: Professional[] = snapshot.docs.map(doc => {
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Agenda</title>
+    <script is:inline>
+      const theme = localStorage.getItem('theme');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      if (theme === 'dark' || (!theme && prefersDark)) {
+        document.documentElement.classList.add('dark');
+      }
+    </script>
   </head>
-<body>
+  <body>
     <div class="flex items-center justify-center min-h-screen">
       <div class="w-full max-w-md bg-card rounded-2xl shadow-lg overflow-hidden m-4">
-        <header class="bg-primary text-primary-foreground p-6 text-center">
-          <h1 class="text-xl font-bold">Agenda tu atención</h1>
-          <p class="text-sm text-primary-foreground/90 mt-1">
-            Sigue los pasos para completar tu reserva.
-          </p>
+        <header class="bg-primary text-primary-foreground p-6 flex items-center">
+          <div class="flex-1 text-center">
+            <h1 class="text-xl font-bold">Agenda tu atención</h1>
+            <p class="text-sm text-primary-foreground/90 mt-1">
+              Sigue los pasos para completar tu reserva.
+            </p>
+          </div>
+          <button
+            id="theme-toggle"
+            type="button"
+            aria-label="Cambiar tema"
+            class="ml-auto text-2xl"
+          >
+            🌓
+          </button>
         </header>
         <div class="p-6 space-y-4">
           {professionals.map((professional) => (
@@ -55,5 +72,11 @@ const professionals: Professional[] = snapshot.docs.map(doc => {
         </div>
       </div>
     </div>
+    <script>
+      document.getElementById('theme-toggle')?.addEventListener('click', () => {
+        const isDark = document.documentElement.classList.toggle('dark');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add theme toggle button and dark mode persistence
- ensure avatar border remains visible in dark mode

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0c3d89f5483278f5d8590dbe72c4d