### PR TITLE
Actualizar iconos de inicio y perfil

### DIFF
--- a/public/doctor-placeholder.svg
+++ b/public/doctor-placeholder.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="#9ca3af">
-  <circle cx="32" cy="24" r="16" />
-  <path d="M8 58c0-13.255 10.745-24 24-24s24 10.745 24 24" />
-</svg>

--- a/src/components/ProfessionalCard.tsx
+++ b/src/components/ProfessionalCard.tsx
@@ -13,7 +13,7 @@ export default function ProfessionalCard({ id, displayName, title, photoURL }: P
       className="flex items-center gap-4 p-4 bg-card rounded-xl shadow-sm border transition hover:shadow-md hover:border-primary"
     >
       <img
-        src={photoURL || '/doctor-placeholder.svg'}
+        src={photoURL || '/doctor-placeholder.png'}
         alt={`Foto de ${displayName}`}
         className="w-16 h-16 rounded-full object-cover"
       />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -45,7 +45,7 @@ const { title, professional } = Astro.props;
                         <div class="w-full max-w-md bg-card rounded-2xl shadow-lg overflow-hidden m-4">
                                 <header class="bg-primary text-primary-foreground p-6 flex items-center gap-4">
                                         <img
-                                                src={professional?.photoURL || '/doctor-placeholder.svg'}
+                                                src={professional?.photoURL || '/doctor-placeholder.png'}
                                                 alt={`Foto de ${professional?.displayName || 'profesional'}`}
                                                 class="w-16 h-16 rounded-full object-cover border-4 border-primary-foreground"
                                         />
@@ -56,8 +56,17 @@ const { title, professional } = Astro.props;
                                         <div class="ml-auto flex items-center gap-4">
                                                 {Astro.url.pathname !== '/' && (
                                                         <a href="/" aria-label="Inicio" class="text-2xl">
-                                                                <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
-                                                                        <path d="M3 9.75L12 3l9 6.75V21a1 1 0 01-1 1h-5.5a.5.5 0 01-.5-.5v-6h-4v6a.5.5 0 01-.5.5H4a1 1 0 01-1-1V9.75z" />
+                                                                <svg
+                                                                        viewBox="0 0 24 24"
+                                                                        fill="none"
+                                                                        stroke="currentColor"
+                                                                        stroke-width="2"
+                                                                        stroke-linecap="round"
+                                                                        stroke-linejoin="round"
+                                                                        class="w-6 h-6"
+                                                                >
+                                                                        <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z" />
+                                                                        <path d="M9 22V12h6v10" />
                                                                 </svg>
                                                         </a>
                                                 )}


### PR DESCRIPTION
## Summary
- Replace filled home icon in header with outlined version
- Update default professional profile picture to new provided image
- Remove doctor-placeholder.png so it can be uploaded manually

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0feebdaa48327b6ebd17e70749143