### PR TITLE
feat: actualiza inicio e icono de home

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,14 +19,14 @@ import ThemeToggle from '../components/ThemeToggle.astro';
       }
     </script>
   </head>
-  <body>
+  <body class="relative">
+    <div class="absolute top-4 right-4">
+      <ThemeToggle />
+    </div>
     <div class="flex items-center justify-center min-h-screen">
       <div class="w-full max-w-md bg-card rounded-2xl shadow-lg overflow-hidden m-4">
-        <div class="relative">
+        <div class="relative bg-[#6c3edc] p-6">
           <img src="/recurso17.png" alt="Seleccionar fecha" class="w-full" />
-          <div class="absolute top-4 right-4">
-            <ThemeToggle />
-          </div>
         </div>
         <div class="p-6 text-center space-y-4">
           <h1 class="text-xl font-bold">Escoge a la persona correcta para el problema correcto</h1>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,7 +10,7 @@ import ThemeToggle from '../components/ThemeToggle.astro';
     <meta name="description" content="Sistema de Agendamiento" />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <title>Bienvenido</title>
+    <title>Inicio</title>
     <script is:inline>
       const theme = localStorage.getItem('theme');
       const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -21,22 +21,24 @@ import ThemeToggle from '../components/ThemeToggle.astro';
   </head>
   <body>
     <div class="flex items-center justify-center min-h-screen">
-      <div class="w-full max-w-md bg-card rounded-2xl shadow-lg overflow-hidden m-4 text-center">
-        <header class="bg-primary text-primary-foreground p-6 flex items-center">
-          <div class="text-left">
-            <h1 class="text-xl font-bold">Bienvenido</h1>
-            <p class="text-sm text-primary-foreground/90 mt-1">Inicia tu reserva en unos simples pasos.</p>
-          </div>
-          <div class="ml-auto flex items-center">
+      <div class="w-full max-w-md bg-card rounded-2xl shadow-lg overflow-hidden m-4">
+        <div class="relative">
+          <img src="/recurso17.png" alt="Seleccionar fecha" class="w-full" />
+          <div class="absolute top-4 right-4">
             <ThemeToggle />
           </div>
-        </header>
-        <div class="p-6">
+        </div>
+        <div class="p-6 text-center space-y-4">
+          <h1 class="text-xl font-bold">Escoge a la persona correcta para el problema correcto</h1>
+          <p class="text-sm text-muted-foreground">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed diam nonummy nibh euismod.
+          </p>
+          <p class="text-sm text-muted-foreground">Lorem ipsum?</p>
           <a
             href="/profesionales"
-            class="block w-full px-6 py-3 border border-primary text-primary font-semibold rounded-lg hover:bg-primary hover:text-primary-foreground transition-colors"
+            class="block w-full px-6 py-3 bg-primary text-primary-foreground font-semibold rounded-lg hover:bg-primary/90 transition-colors"
           >
-            Comenzar
+            Reservar hora
           </a>
         </div>
       </div>

--- a/src/pages/profesionales/index.astro
+++ b/src/pages/profesionales/index.astro
@@ -53,8 +53,17 @@ const professionals: Professional[] = snapshot.docs.map(doc => {
           </div>
           <div class="ml-auto flex items-center gap-4">
             <a href="/" aria-label="Inicio" class="text-2xl">
-              <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
-                <path d="M3 9.75L12 3l9 6.75V21a1 1 0 01-1 1h-5.5a.5.5 0 01-.5-.5v-6h-4v6a.5.5 0 01-.5.5H4a1 1 0 01-1-1V9.75z" />
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="w-6 h-6"
+              >
+                <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z" />
+                <path d="M9 22V12h6v10" />
               </svg>
             </a>
             <ThemeToggle />


### PR DESCRIPTION
## Summary
- utiliza el mismo icono de inicio del formulario en la pantalla de profesionales
- rediseña la pantalla inicial con la referencia de recurso17 e incluye botón "Reservar hora"
- elimina el recurso temporal `recurso17.png`

## Testing
- `npm test` *(missing script: test)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1057a34488327aeb687a2afba661a