### PR TITLE
Use classList.toggle for theme initialization

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -36,9 +36,10 @@ const { title, professional } = Astro.props;
                 <script is:inline>
                         const theme = localStorage.getItem('theme');
                         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-                        if (theme === 'dark' || (!theme && prefersDark)) {
-                                document.documentElement.classList.add('dark');
-                        }
+                        document.documentElement.classList.toggle(
+                                'dark',
+                                theme === 'dark' || (!theme && prefersDark)
+                        );
                 </script>
         </head>
         <body>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,9 +15,10 @@ import { createRipple, rippleClasses } from '../utils/ripple';
     <script is:inline>
       const theme = localStorage.getItem('theme');
       const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      if (theme === 'dark' || (!theme && prefersDark)) {
-        document.documentElement.classList.add('dark');
-      }
+      document.documentElement.classList.toggle(
+        'dark',
+        theme === 'dark' || (!theme && prefersDark)
+      );
     </script>
   </head>
   <body class="relative">

--- a/src/pages/profesionales/index.astro
+++ b/src/pages/profesionales/index.astro
@@ -36,9 +36,10 @@ const professionals: Professional[] = snapshot.docs.map(doc => {
     <script is:inline>
       const theme = localStorage.getItem('theme');
       const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      if (theme === 'dark' || (!theme && prefersDark)) {
-        document.documentElement.classList.add('dark');
-      }
+      document.documentElement.classList.toggle(
+        'dark',
+        theme === 'dark' || (!theme && prefersDark)
+      );
     </script>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- simplify theme initialization by using `classList.toggle` based on stored or preferred theme

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a298ba578c8327a634f0defeb6acf4