### PR TITLE
Ignore cancelled appointments in availability

### DIFF
--- a/src/pages/api/availability.ts
+++ b/src/pages/api/availability.ts
@@ -50,11 +50,7 @@ export const POST: APIRoute = async ({ request }) => {
       collection(db, 'appointments'),
       where('professionalId', '==', professionalId),
       where('start', '>=', Timestamp.fromDate(startOfSelectedDay)),
-      where('start', '<=', Timestamp.fromDate(endOfSelectedDay)),
-      // Exclude cancelled appointments if Firestore supports the '!=' operator
-      // Otherwise, we'll filter them out after fetching
-      // @ts-ignore - Some Firestore versions may not support this query
-      where('status', '!=', 'cancelled')
+      where('start', '<=', Timestamp.fromDate(endOfSelectedDay))
     );
 
     const timeBlocksQuery = query(


### PR DESCRIPTION
## Summary
- filter out cancelled appointments when computing availability
- only block time slots using active appointments, time blocks and breaks

## Testing
- `npm run build`
- Manual script verifying cancelled appointments no longer block slots

------
https://chatgpt.com/codex/tasks/task_e_68a29cba41788327afa14c5f7a73c8c7