### PR TITLE
refactor: hide search during loading

### DIFF
--- a/src/components/ProfessionalSearch.tsx
+++ b/src/components/ProfessionalSearch.tsx
@@ -57,36 +57,41 @@ export default function ProfessionalSearch() {
 
   return (
     <div className="space-y-6 text-left">
-      <div className="relative">
-        <FiSearch className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
-        <input
-          type="text"
-          placeholder="Buscar profesional por nombre o email"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          className="w-full p-2 pl-8 border rounded-lg bg-background text-foreground placeholder:text-muted-foreground"
-        />
-      </div>
-      <div className="flex flex-col gap-4">
-        {isLoading && (
-          <div className="flex flex-col items-center gap-2 py-8">
-            <FiLoader className="h-6 w-6 animate-spin text-primary" />
-            <p className="text-center">cargando...</p>
-          </div>
-        )}
-        {error && <p className="py-8 text-center">{error}</p>}
-        {!isLoading && !error &&
-          results.map((p) => (
-            <ProfessionalCard
-              key={p.id}
-              id={p.id}
-              displayName={p.displayName}
-              title={p.title}
-              email={p.email}
-              photoURL={p.photoURL}
+      {isLoading ? (
+        <div className="flex flex-col items-center gap-2 py-8">
+          <FiLoader className="h-6 w-6 animate-spin text-primary" />
+          <p className="text-center">Buscando datos de profesionales…</p>
+        </div>
+      ) : (
+        <>
+          <div className="relative">
+            <FiSearch className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
+            <input
+              type="text"
+              placeholder="Buscar profesional por nombre o email"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="w-full p-2 pl-8 border rounded-lg bg-background text-foreground placeholder:text-muted-foreground"
             />
-          ))}
-      </div>
+          </div>
+          <div className="flex flex-col gap-4">
+            {error ? (
+              <p className="py-8 text-center">{error}</p>
+            ) : (
+              results.map((p) => (
+                <ProfessionalCard
+                  key={p.id}
+                  id={p.id}
+                  displayName={p.displayName}
+                  title={p.title}
+                  email={p.email}
+                  photoURL={p.photoURL}
+                />
+              ))
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,51 +1,32 @@
 ---
-import '../styles/global.css';
+import Layout from '../layouts/Layout.astro';
 import ThemeToggle from '../components/ThemeToggle.astro';
 import ProfessionalSearch from '../components/ProfessionalSearch';
 ---
 
-<!doctype html>
-<html lang="es">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="description" content="Sistema de Agendamiento" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <title>Inicio</title>
-    <script is:inline>
-      const theme = localStorage.getItem('theme');
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      document.documentElement.classList.toggle(
-        'dark',
-        theme === 'dark' || (!theme && prefersDark)
-      );
-    </script>
-  </head>
-  <body class="relative min-h-screen">
-    <div class="absolute top-4 right-4">
-      <ThemeToggle />
-    </div>
-    <div class="min-h-screen md:flex md:items-center md:justify-center">
-      <div class="w-full h-full bg-card md:max-w-md md:rounded-2xl md:shadow-lg md:overflow-hidden md:m-4">
-        <div class="relative bg-[#6c3edc] p-6">
-          <img src="/recurso17.png" alt="Seleccionar fecha" class="w-full" />
-        </div>
-        <div class="p-6 text-center space-y-4">
-          <h1 class="text-xl font-bold">¡Bienvenido a Gestión de Agenda!</h1>
-          <p class="text-sm text-muted-foreground">
-            Utiliza esta plataforma para reservar citas con nuestros profesionales de forma rápida y sencilla.
-          </p>
-          <p class="text-sm text-muted-foreground">
-            Busca un profesional por nombre o correo para continuar con el formulario de reserva.
-          </p>
-          <div class="flex items-center gap-2">
-            <div class="flex-grow">
-              <ProfessionalSearch client:load />
-            </div>
+<Layout title="Inicio">
+  <div class="absolute top-4 right-4">
+    <ThemeToggle />
+  </div>
+  <div class="min-h-screen md:flex md:items-center md:justify-center">
+    <div class="w-full h-full bg-card md:max-w-md md:rounded-2xl md:shadow-lg md:overflow-hidden md:m-4">
+      <div class="relative bg-[#6c3edc] p-6">
+        <img src="/recurso17.png" alt="Seleccionar fecha" class="w-full" />
+      </div>
+      <div class="p-6 text-center space-y-4">
+        <h1 class="text-xl font-bold">¡Bienvenido a Gestión de Agenda!</h1>
+        <p class="text-sm text-muted-foreground">
+          Utiliza esta plataforma para reservar citas con nuestros profesionales de forma rápida y sencilla.
+        </p>
+        <p class="text-sm text-muted-foreground">
+          Busca un profesional por nombre o correo para continuar con el formulario de reserva.
+        </p>
+        <div class="flex items-center gap-2">
+          <div class="flex-grow">
+            <ProfessionalSearch client:load />
           </div>
         </div>
+      </div>
     </div>
   </div>
-  <script src="/js/view-transitions.js" defer></script>
-  </body>
-</html>
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,6 +22,9 @@ import ProfessionalSearch from '../components/ProfessionalSearch';
     </script>
   </head>
   <body class="relative min-h-screen">
+    <div class="absolute top-4 right-4">
+      <ThemeToggle />
+    </div>
     <div class="min-h-screen md:flex md:items-center md:justify-center">
       <div class="w-full h-full bg-card md:max-w-md md:rounded-2xl md:shadow-lg md:overflow-hidden md:m-4">
         <div class="relative bg-[#6c3edc] p-6">
@@ -39,7 +42,6 @@ import ProfessionalSearch from '../components/ProfessionalSearch';
             <div class="flex-grow">
               <ProfessionalSearch client:load />
             </div>
-            <ThemeToggle />
           </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- hide search input and results until professional data loads
- show spinner and message during loading

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9e61e2cdc8327bdab95e9d57dcd52