### PR TITLE
Refactor home page to use shared layout

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -45,23 +45,29 @@ const { title, professional } = Astro.props;
         <body class="min-h-screen">
                 <div class="min-h-screen md:flex md:items-center md:justify-center">
                         <div class="w-full h-full bg-card md:max-w-md md:rounded-2xl md:shadow-lg md:overflow-hidden md:m-4">
-                                <header class="bg-primary text-primary-foreground px-6 py-4 flex items-center gap-4">
-                                        <img
-                                                src={professional?.photoURL || '/doctor-placeholder.png'}
-                                                alt={`Foto de ${professional?.displayName || 'profesional'}`}
-                                                class="w-16 h-16 rounded-full object-cover border-4 border-primary-foreground"
-                                        />
-                                        <div>
-                                                <h1 class="text-xl font-bold">{professional?.displayName}</h1>
-                                                <p class="text-sm">{professional?.title}</p>
+                                {professional && (
+                                        <header class="bg-primary text-primary-foreground px-6 py-4 flex items-center gap-4">
+                                                <img
+                                                        src={professional.photoURL || '/doctor-placeholder.png'}
+                                                        alt={`Foto de ${professional.displayName}`}
+                                                        class="w-16 h-16 rounded-full object-cover border-4 border-primary-foreground"
+                                                />
+                                                <div>
+                                                        <h1 class="text-xl font-bold">{professional.displayName}</h1>
+                                                        <p class="text-sm">{professional.title}</p>
+                                                </div>
+                                                <div class="ml-auto flex items-center gap-4">
+                                                        <ThemeToggle />
+                                                </div>
+                                        </header>
+                                )}
+                                {professional ? (
+                                        <div class="px-6 pt-4 pb-6">
+                                                <slot />
                                         </div>
-                                        <div class="ml-auto flex items-center gap-4">
-                                                <ThemeToggle />
-                                        </div>
-                                </header>
-                                <div class="px-6 pt-4 pb-6">
+                                ) : (
                                         <slot />
-                                </div>
+                                )}
                         </div>
                 </div>
                 <script src="/js/view-transitions.js" defer></script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,55 +1,26 @@
 ---
-import '../styles/global.css';
+import Layout from '../layouts/Layout.astro';
 import ThemeToggle from '../components/ThemeToggle.astro';
 import ProfessionalSearch from '../components/ProfessionalSearch';
 ---
 
-<!doctype html>
-<html lang="es">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="description" content="Sistema de Agendamiento" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;700;800&display=swap"
-      rel="stylesheet"
-    />
-    <title>Inicio</title>
-    <script is:inline>
-      const theme = localStorage.getItem('theme');
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      document.documentElement.classList.toggle(
-        'dark',
-        theme === 'dark' || (!theme && prefersDark)
-      );
-    </script>
-  </head>
-  <body class="relative min-h-screen">
-    <div class="min-h-screen md:flex md:items-center md:justify-center">
-      <div class="w-full h-full bg-card md:max-w-md md:rounded-2xl md:shadow-lg md:overflow-hidden md:m-4">
-        <div class="relative bg-[#6c3edc] p-6">
-          <img src="/recurso17.png" alt="Seleccionar fecha" class="w-full" />
-        </div>
-        <div class="p-6 text-center space-y-4">
-          <h1 class="text-xl font-bold">¡Bienvenido a Gestión de Agenda!</h1>
-          <p class="text-sm text-muted-foreground">
-            Utiliza esta plataforma para reservar citas con nuestros profesionales de forma rápida y sencilla.
-          </p>
-          <p class="text-sm text-muted-foreground">
-            Busca un profesional por nombre o correo para continuar con el formulario de reserva.
-          </p>
-          <div class="flex items-center gap-2">
-            <div class="flex-grow">
-              <ProfessionalSearch client:load />
-            </div>
-            <ThemeToggle />
-          </div>
-        </div>
+<Layout title="Inicio">
+  <div class="relative bg-[#6c3edc] p-6">
+    <img src="/recurso17.png" alt="Seleccionar fecha" class="w-full" />
+  </div>
+  <div class="p-6 text-center space-y-4">
+    <h1 class="text-xl font-bold">¡Bienvenido a Gestión de Agenda!</h1>
+    <p class="text-sm text-muted-foreground">
+      Utiliza esta plataforma para reservar citas con nuestros profesionales de forma rápida y sencilla.
+    </p>
+    <p class="text-sm text-muted-foreground">
+      Busca un profesional por nombre o correo para continuar con el formulario de reserva.
+    </p>
+    <div class="flex items-center gap-2">
+      <div class="flex-grow">
+        <ProfessionalSearch client:load />
+      </div>
+      <ThemeToggle />
     </div>
   </div>
-  <script src="/js/view-transitions.js" defer></script>
-  </body>
-</html>
+</Layout>


### PR DESCRIPTION
## Summary
- make header and padding optional in `Layout.astro` so pages without a professional can reuse it
- use the shared layout in the home page and remove duplicated markup

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9e98f4ad8832780d293ccbf125bd2