### PR TITLE
fix: show theme toggle on mobile

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,7 +5,7 @@ import ProfessionalSearch from '../components/ProfessionalSearch';
 ---
 
 <Layout title="Inicio">
-<div class="absolute top-4 right-4">
+<div class="fixed top-4 right-4 z-50">
     <ThemeToggle />
   </div>
   <div class="min-h-screen md:flex md:items-center md:justify-center">


### PR DESCRIPTION
## Summary
- ensure theme toggle is visible on mobile by fixing its positioning and z-index

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad207537e083278bcd4fc4fb155e40