### PR TITLE
Defer RandomGradientAvatar gradient to client-side

### DIFF
--- a/src/components/common/Avatar/RandomGradientAvatar.tsx
+++ b/src/components/common/Avatar/RandomGradientAvatar.tsx
@@ -1,13 +1,17 @@
 import NeutralAvatar from './NeutralAvatar.svg?react';
 import randomGradient from '../../../utils/randomGradient';
-import { useMemo, type HTMLAttributes } from 'react';
+import { useEffect, useState, type HTMLAttributes } from 'react';
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
   alt?: string;
 }
 
 export default function RandomGradientAvatar({ className = '', alt, ...props }: Props) {
-  const gradient = useMemo(() => randomGradient(), []);
+  const [gradient, setGradient] = useState('');
+
+  useEffect(() => {
+    setGradient(randomGradient());
+  }, []);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- compute random avatar gradient after mount to avoid SSR mismatch

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae4c890a348327a9ac5f148c5fa587