### PR TITLE
Remove internal scroll from search results

### DIFF
--- a/src/components/ProfessionalSearch.tsx
+++ b/src/components/ProfessionalSearch.tsx
@@ -20,7 +20,6 @@ export default function ProfessionalSearch() {
   const [professionals, setProfessionals] = useState<Professional[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [isFocused, setIsFocused] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -72,18 +71,12 @@ export default function ProfessionalSearch() {
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               onFocus={() => {
-                setIsFocused(true);
                 containerRef.current?.scrollIntoView({ behavior: 'smooth' });
               }}
-              onBlur={() => setIsFocused(false)}
               className="w-full p-2 pl-8 border rounded-lg bg-background text-foreground placeholder:text-muted-foreground"
             />
           </div>
-          <div
-            className={`flex flex-col gap-4 ${
-              isFocused ? 'max-h-[calc(100vh-4rem)] overflow-y-auto' : ''
-            }`}
-          >
+          <div className="flex flex-col gap-4 overflow-visible">
             {error ? (
               <p className="py-8 text-center">{error}</p>
             ) : (


### PR DESCRIPTION
## Summary
- remove focus-based internal scrolling from ProfessionalSearch results
- ensure results container uses page-level scrolling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b72be6ec1c8327ae776f3d53557e87